### PR TITLE
add-registry: fix KeyError 'unqualified-search-registries' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ registries-conf-ctl. A CLI tool to modify
 Usage:
   registries-conf-ctl [options] add-mirror <registry> <mirror> [--insecure] [--http]
   registries-conf-ctl [options] list-mirrors <registry>
+  registries-conf-ctl [options] add-registry <registry> [--location=location] [--insecure] [--unqualified-search]
   registries-conf-ctl -h | --help
   registries-conf-ctl --version
-
 Options:
   -h --help      Show this screen.
   --version      Show version.
   --conf=<conf>  registries.conf [default: /etc/containers/registries.conf,/etc/docker/daemon.json].
+  --docker       Treat `--conf` as a docker config file
   --insecure     Mark registry as insecure
   --http         HTTP registry mirror (Docker only)
 ```

--- a/registries_conf_ctl/cli.py
+++ b/registries_conf_ctl/cli.py
@@ -184,7 +184,7 @@ class RegistriesConfV2(Fmt):
         # type: (dict) -> Dict[str, Reg]
         if config:
             if 'registries' not in config:  # is_v2:
-                search = config['unqualified-search-registries']
+                search = config.get('unqualified-search-registries', [])
                 ret = {
                     reg['prefix']: Reg(prefix=reg['prefix'],
                         location=reg.get('location', reg['prefix']),

--- a/tests/test_add_registry.py
+++ b/tests/test_add_registry.py
@@ -49,6 +49,12 @@ blocked = false
 v2_empty = u"""
 """
 
+v2_small = u"""
+[[registry]]
+prefix = "quay.io"
+"""
+
+
 reg_expected = {
     'unqualified-search-registries': ['docker.io', 'quay.io', 'registry.access.redhat.com', 'registry.redhat.io'],
     'registry': [
@@ -76,9 +82,13 @@ docker_out = {
     "registry-mirrors": ["http://vossi04.front.sepia.ceph.com:5000"]
 }
 
-
-def test_add_registry_simple():
-    fmt = cli.RegistriesConfV2(StringIO(v1_empty))
+@pytest.mark.parametrize('input',
+[
+    v1_empty,
+    v2_small,
+])
+def test_add_registry_simple(input):
+    fmt = cli.RegistriesConfV2(StringIO(input))
     fmt.add_registry('localhost', '', True, False)
     assert fmt.dump_json() == {
         'registry': [


### PR DESCRIPTION
Cause this key is not mandatory

Fixes: #5

Signed-off-by: Sebastian Wagner <sewagner@redhat.com>